### PR TITLE
Add GitHub Actions workflow for build and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux]
+        goarch: [amd64, arm64]
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
+
+    - name: Build
+      run: |
+        GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o myapp ./agent/cmd/runner
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: myapp-${{ matrix.goos }}-${{ matrix.goarch }}
+        path: myapp
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: myapp-linux-amd64
+
+    - name: Set up SLSA Generator
+      uses: slsa-framework/slsa-github-generator@v1
+      with:
+        artifact-path: myapp-linux-amd64
+
+    - name: Create GitHub Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v1.0.0
+        release_name: Release v1.0.0
+        draft: false
+        prerelease: false
+        files: myapp-linux-amd64


### PR DESCRIPTION
# 背景
`agent/cmd/runner/main.go`をビルドしてGitHub Packageにリリースするためのワークフローが必要でした。

# 内容
GitHub Actionsを使用して、コードがプッシュされたときにビルドとリリースを行うワークフローを追加しました。`slsa-github-generator`を使用して、SLSAレベル3のプロビナンスを生成し、AMDおよびARMアーキテクチャ向けにクロスコンパイルを行います。

# Issue
課題番号 /usr/local/agent/.tmp/issue.md