### PR TITLE
Add GitHub Actions workflow and update README

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,54 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go-version: [1.23.x]
+        platform: [amd64, arm64]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Build
+      run: |
+        GOOS=linux GOARCH=${{ matrix.platform }} go build -o myapp-agent ./agent/cmd/runner
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: myapp-agent-${{ matrix.platform }}
+        path: myapp-agent
+
+    - name: Generate SLSA provenance
+      uses: slsa-framework/slsa-github-generator@v1.3.0
+      with:
+        builder: 'https://github.com/slsa-framework/slsa-github-generator'
+
+    - name: Verify SLSA provenance
+      uses: slsa-framework/slsa-verifier@v1.3.0
+      with:
+        provenance: provenance.json
+
+    - name: Publish to GitHub Packages
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./myapp-agent
+        asset_name: myapp-agent-${{ matrix.platform }}
+        asset_content_type: application/octet-stream

--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ docker compose run --rm \
   - Git clone at /usr/local/repositories
   - LLM OPENAI_API_KEY or ANTHROPIC_API_KEY is required
 1. Human review of work product by agent
+
+## GitHub Actions Workflow
+
+This repository includes a GitHub Actions workflow to build and release the `agent/cmd/runner/main.go` project. The workflow is triggered on pushes to the `main` branch and on release creation. It builds the project for both AMD and ARM architectures, generates SLSA provenance, and uploads the binaries to GitHub Packages.
+
+To set up the workflow, ensure that the `.github/workflows/build-and-release.yml` file is present in the repository.


### PR DESCRIPTION
## 背景
`agent/cmd/runner/main.go`をビルドしてGitHub PackageにリリースするためのGitHub Actionsのワークフローを作成しました。これにより、AMDおよびARMアーキテクチャ向けのバイナリリリースが可能になります。

## 内容
- `.github/workflows/build-and-release.yml`を作成し、ビルドとリリースの自動化を設定しました。
- `README.md`にワークフローの設定方法と使用方法についての説明を追加しました。

## Issue
/usr/local/agent/.tmp/issue.md