### PR TITLE
Add GitHub Actions workflow for build and release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,65 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go-version: [1.15, 1.16]
+        platform: [amd64, arm64]
+
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Build
+      run: |
+        GOOS=linux GOARCH=${{ matrix.platform }} go build -o myapp-agent ./agent/cmd/runner
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: myapp-agent-${{ matrix.platform }}
+        path: myapp-agent
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: myapp-agent-${{ matrix.platform }}
+
+    - name: Create Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v1.0.0
+        release_name: Release v1.0.0
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: myapp-agent-${{ matrix.platform }}
+        asset_name: myapp-agent-${{ matrix.platform }}
+        asset_content_type: application/octet-stream


### PR DESCRIPTION
# 背景
`agent/cmd/runner/main.go`をビルドしてGitHub PackageにリリースするためのGitHub Actionsのワークフローを作成しました。これにより、異なるアーキテクチャ（AMD, ARM）向けのバイナリを自動的にビルドし、リリースすることが可能になります。

# 内容
- `.github/workflows/build-and-release.yml`ファイルを作成し、GitHub Actionsのワークフローを定義しました。
- ワークフローは、mainブランチへのプッシュまたはプルリクエスト時にトリガーされます。
- Goのバージョン1.15と1.16を使用して、AMD64とARM64プラットフォーム向けにビルドします。
- ビルドされたバイナリをアーティファクトとしてアップロードし、リリース時にそれをGitHub Packageにアップロードします。

# Issue
/usr/local/agent/.tmp/issue.md