### PR TITLE
Add tests for put_file.go and update Makefile

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -5,3 +5,6 @@ $(TEMPDIR):
 
 build: $(TEMPDIR)
 	cd cmd/runner && go build -o ../../$(TEMPDIR)/build/agent
+
+test:
+	go test ./functions/...

--- a/agent/functions/put_file_test.go
+++ b/agent/functions/put_file_test.go
@@ -1,0 +1,54 @@
+package functions
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPutFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       PutFileInput
+		wantErr     bool
+		checkOutput func(t *testing.T, input PutFileInput)
+	}{
+		{
+			name: "valid path and content",
+			input: PutFileInput{
+				OutputPath:  "testdata/testfile.txt",
+				ContentText: "Hello, World!",
+			},
+			wantErr: false,
+			checkOutput: func(t *testing.T, input PutFileInput) {
+				content, err := os.ReadFile(input.OutputPath)
+				if err != nil {
+					t.Fatalf("failed to read file: %v", err)
+				}
+				if string(content) != input.ContentText+"\n" {
+					t.Errorf("got %s, want %s", content, input.ContentText+"\n")
+				}
+			},
+		},
+		{
+			name: "invalid path",
+			input: PutFileInput{
+				OutputPath:  "/invalidpath/testfile.txt",
+				ContentText: "Hello, World!",
+			},
+			wantErr: true,
+			checkOutput: func(t *testing.T, input PutFileInput) {},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := PutFile(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PutFile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.checkOutput != nil {
+				tt.checkOutput(t, tt.input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# 背景
`functions/put_file.go`のテストを実装する必要がありました。また、テストを簡単に実行できるようにするため、Makefileにテストターゲットを追加しました。

# 内容
- `functions/put_file_test.go`を作成し、正常系と異常系のテストケースを実装しました。
- `Makefile`に`test`ターゲットを追加し、`go test ./functions/...`コマンドでテストを実行できるようにしました。

# Issue
3