### PR TITLE
Add tests for PutFile and update Makefile

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -5,3 +5,6 @@ $(TEMPDIR):
 
 build: $(TEMPDIR)
 	cd cmd/runner && go build -o ../../$(TEMPDIR)/build/agent
+
+test:
+	go test ./... -v

--- a/agent/functions/put_file_test.go
+++ b/agent/functions/put_file_test.go
@@ -1,0 +1,51 @@
+package functions_test
+
+import (
+	"os"
+	"testing"
+
+	"github/clover0/github-issue-agent/functions"
+	"github/clover0/github-issue-agent/store"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPutFile(t *testing.T) {
+	t.Run("successfully creates a file", func(t *testing.T) {
+		input := functions.PutFileInput{
+			OutputPath:  "testdata/testfile.txt",
+			ContentText: "Hello, World!",
+		}
+
+		file, err := functions.PutFile(input)
+		assert.NoError(t, err)
+		assert.Equal(t, input.OutputPath, file.Path)
+		assert.Equal(t, input.ContentText+"\n", file.Content)
+
+		// Clean up
+		os.Remove(input.OutputPath)
+	})
+
+	t.Run("returns error for invalid path", func(t *testing.T) {
+		input := functions.PutFileInput{
+			OutputPath:  "",
+			ContentText: "Hello, World!",
+		}
+
+		_, err := functions.PutFile(input)
+		assert.Error(t, err)
+	})
+
+	t.Run("writes content correctly", func(t *testing.T) {
+		input := functions.PutFileInput{
+			OutputPath:  "testdata/testfile2.txt",
+			ContentText: "Test Content",
+		}
+
+		file, err := functions.PutFile(input)
+		assert.NoError(t, err)
+		assert.Equal(t, input.ContentText+"\n", file.Content)
+
+		// Clean up
+		os.Remove(input.OutputPath)
+	})
+}


### PR DESCRIPTION
# 背景
`put_file.go`のテストを実装するために、テストファイルを作成し、Makefileを更新しました。

# 内容
- `put_file_test.go`を作成し、`PutFile`関数のテストケースを追加しました。
- `Makefile`にテストを実行するターゲットを追加しました。

# Issue
/usr/local/agent/.tmp/issue_3.md