### PR TITLE
Implement tests for put_file.go and create Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+test:
+	go test ./...
+
+build:
+	go build -o bin/app ./cmd/app

--- a/agent/functions/put_file_test.go
+++ b/agent/functions/put_file_test.go
@@ -1,0 +1,45 @@
+package functions_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github/clover0/github-issue-agent/functions"
+)
+
+func TestPutFile(t *testing.T) {
+	t.Run("successfully writes content to file", func(t *testing.T) {
+		outputPath := "testdata/testfile.txt"
+		content := "Hello, World!"
+
+		defer os.Remove(outputPath)
+
+		file, err := functions.PutFile(functions.PutFileInput{
+			OutputPath:  outputPath,
+			ContentText: content,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, outputPath, file.Path)
+		assert.Equal(t, content+"\n", file.Content)
+
+		actualContent, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		assert.Equal(t, content+"\n", string(actualContent))
+	})
+
+	t.Run("fails with invalid path", func(t *testing.T) {
+		outputPath := "invalid_path/testfile.txt"
+		content := "Hello, World!"
+
+		_, err := functions.PutFile(functions.PutFileInput{
+			OutputPath:  outputPath,
+			ContentText: content,
+		})
+
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
# 背景
`put_file.go`の機能をテストするために、テストファイルとMakefileを作成しました。これにより、コードの信頼性を高め、将来的な変更に対する安全性を確保します。

# 内容
- `put_file_test.go`を作成し、正常系と異常系のテストケースを実装しました。
- プロジェクトのルートディレクトリに`Makefile`を作成し、テストとビルドのターゲットを追加しました。

# Issue
/usr/local/agent/.tmp/issue_3.md