### PR TITLE
Add guard_test.go and Makefile for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: test
+test:
+	go test ./... -v
+
+.PHONY: test-coverage
+test-coverage:
+	go test ./... -coverprofile=coverage.out
+	go tool cover -html=coverage.out -o coverage.html

--- a/agent/functions/guard_test.go
+++ b/agent/functions/guard_test.go
@@ -1,0 +1,75 @@
+package functions
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGuardPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "正常系: 通常のパス",
+			path:    "path/to/file.txt",
+			wantErr: false,
+			errMsg:  "",
+		},
+		{
+			name:    "正常系: 空のパス",
+			path:    "",
+			wantErr: false,
+			errMsg:  "",
+		},
+		{
+			name:    "異常系: 親ディレクトリ参照",
+			path:    "../path/to/file",
+			wantErr: true,
+			errMsg:  "contains not allowed '..'",
+		},
+		{
+			name:    "異常系: チルダ使用",
+			path:    "~/path/to/file",
+			wantErr: true,
+			errMsg:  "contains not allowed '~'",
+		},
+		{
+			name:    "異常系: 重複スラッシュ",
+			path:    "path//to/file",
+			wantErr: true,
+			errMsg:  "contains not allowed '//'",
+		},
+		{
+			name:    "異常系: ルートパス開始",
+			path:    "/path/to/file",
+			wantErr: true,
+			errMsg:  "starts with '/', not allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := guardPath(tt.path)
+			
+			// エラーの有無を検証
+			if (err != nil) != tt.wantErr {
+				t.Errorf("guardPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// エラーメッセージの検証
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("guardPath() error message = %v, want containing %v", err.Error(), tt.errMsg)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
from Agent

# 背景
guardPath関数のテストが未実装であり、テスト実行のための環境も整っていなかったため、テストコードの実装とテスト実行環境の整備を行いました。

# 内容
1. guard_test.goの実装
- テーブル駆動テストを使用して、guardPath関数の全パターンをカバーするテストを実装
- 正常系（通常のパス、空のパス）と異常系（親ディレクトリ参照、チルダ使用、重複スラッシュ、ルートパス開始）のテストケースを網羅
- エラーメッセージの検証も含めた完全なテストを実装

2. Makefileの作成
- `make test`コマンドでテストを実行可能に
- `make test-coverage`コマンドでカバレッジレポートを生成可能に
- HTMLフォーマットでのカバレッジレポート出力機能を追加

# Issue
3